### PR TITLE
Switch agent API to OpenAI Platform

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -3,10 +3,8 @@
 ## Deploy
 1. Push to GitHub and import the repo in Vercel.
 2. Add Env Vars in Vercel → Settings → Environment Variables:
-   - AZURE_OPENAI_ENDPOINT = https://<your-resource>.openai.azure.com
-   - AZURE_OPENAI_API_KEY = <key>
-   - AZURE_OPENAI_DEPLOYMENT = gpt-4o-mini
-   - AZURE_OPENAI_API_VERSION = 2024-10-21
+   - OPENAI_API_KEY = <key>
+   - OPENAI_MODEL = gpt-4o-mini
 3. Visit `/` → redirects to `/INDEX.html` (your Demo_0005).
 
 ## Excel-driven refresh

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -7,7 +7,7 @@ type ChatRequestBody = {
   message?: unknown;
 };
 
-type AzureChatCompletion = {
+type OpenAIChatCompletion = {
   choices?: Array<{
     message?: {
       content?: string;
@@ -35,26 +35,21 @@ export async function POST(req: NextRequest) {
     : 'Hello';
 
   try {
-    const endpoint = process.env.AZURE_OPENAI_ENDPOINT;
-    const deployment = process.env.AZURE_OPENAI_DEPLOYMENT;
-    const apiVersion = process.env.AZURE_OPENAI_API_VERSION;
-    const apiKey = process.env.AZURE_OPENAI_API_KEY;
+    const apiKey = process.env.OPENAI_API_KEY;
+    const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
 
-    validateEnv('AZURE_OPENAI_ENDPOINT', endpoint);
-    validateEnv('AZURE_OPENAI_DEPLOYMENT', deployment);
-    validateEnv('AZURE_OPENAI_API_VERSION', apiVersion);
-    validateEnv('AZURE_OPENAI_API_KEY', apiKey);
+    validateEnv('OPENAI_API_KEY', apiKey);
 
-    const url = new URL(`/openai/deployments/${deployment}/chat/completions`, endpoint);
-    url.searchParams.set('api-version', apiVersion);
+    const url = 'https://api.openai.com/v1/chat/completions';
 
-    const response = await fetch(url.toString(), {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'api-key': apiKey,
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
+        model,
         messages: [
           {
             role: 'system',
@@ -75,7 +70,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'LLM error', detail }, { status: 500 });
     }
 
-    const data = (await response.json()) as AzureChatCompletion;
+    const data = (await response.json()) as OpenAIChatCompletion;
     const text = data?.choices?.[0]?.message?.content ?? '';
 
     return NextResponse.json({ text });

--- a/app/api/agent/stream/route.ts
+++ b/app/api/agent/stream/route.ts
@@ -3,12 +3,28 @@ export const preferredRegion=['sin1','hkg1','bom1'];
 import { NextRequest } from 'next/server';
 export async function POST(req: NextRequest) {
   const { message } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
+
+  if (!apiKey || !model) {
+    return new Response(
+      `event: error\ndata: ${JSON.stringify({ detail: 'Missing required environment variables for OpenAI' })}\n\n`,
+      {
+        headers: {
+          'Content-Type': 'text/event-stream; charset=utf-8',
+          'Cache-Control': 'no-cache, no-transform',
+          Connection: 'keep-alive',
+        },
+        status: 500,
+      },
+    );
+  }
   const encoder = new TextEncoder();
   const stream = new ReadableStream({
     async start(controller){
       try{
-        const url = `${process.env.AZURE_OPENAI_ENDPOINT}/openai/deployments/${process.env.AZURE_OPENAI_DEPLOYMENT}/chat/completions?api-version=${process.env.AZURE_OPENAI_API_VERSION}`;
-        const resp = await fetch(url, { method:'POST', headers:{ 'content-type':'application/json', 'api-key': process.env.AZURE_OPENAI_API_KEY! }, body: JSON.stringify({ messages:[{role:'system',content:'You are a helpful assistant for a Singapore Government analysis portal.'},{role:'user',content: message||'Hello'}], temperature:0.2, max_tokens:600, stream:true }) });
+        const url = 'https://api.openai.com/v1/chat/completions';
+        const resp = await fetch(url, { method:'POST', headers:{ 'content-type':'application/json', Authorization: `Bearer ${apiKey}` }, body: JSON.stringify({ model, messages:[{role:'system',content:'You are a helpful assistant for a Singapore Government analysis portal.'},{role:'user',content: message||'Hello'}], temperature:0.2, max_tokens:600, stream:true }) });
         if(!resp.ok || !resp.body){ const detail = await resp.text(); controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ detail })}\n\n`)); controller.close(); return; }
         const reader = resp.body.getReader(); const decoder = new TextDecoder(); let buffer='';
         while(true){ const { value, done } = await reader.read(); if(done) break; buffer += decoder.decode(value, { stream:true });

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-export const metadata: Metadata = { title: 'Demo 0005 – Vercel', description: 'Static demo with Azure OpenAI agent' };
+export const metadata: Metadata = { title: 'Demo 0005 – Vercel', description: 'Static demo with OpenAI Platform agent' };
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (<html lang="en"><body style={{margin:0}}>{children}</body></html>);
 }

--- a/public/INDEX.html
+++ b/public/INDEX.html
@@ -1203,7 +1203,7 @@
     <div class="chat-row">
       <textarea id="ai-chat-input" class="chat-input" placeholder="Ask the agent about usage, costs, or insights..."></textarea>
       <button id="ai-chat-send" class="chat-send">Send</button>
-      <small class="chat-hint">Azure OpenAI</small>
+      <small class="chat-hint">OpenAI Platform</small>
     </div>
     <div id="ai-chat-output" class="chat-output"></div>
   </div>


### PR DESCRIPTION
## Summary
- replace the Azure OpenAI REST calls with OpenAI Platform chat completions endpoints for both standard and streaming agent routes
- refresh documentation, layout metadata, and UI text to reference the OpenAI Platform configuration

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db02e0acf483269e9bc91bda7d365a