### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -3,10 +3,8 @@
 ## Deploy
 1. Push to GitHub and import the repo in Vercel.
 2. Add Env Vars in Vercel → Settings → Environment Variables:
-   - AZURE_OPENAI_ENDPOINT = https://<your-resource>.openai.azure.com
-   - AZURE_OPENAI_API_KEY = <key>
-   - AZURE_OPENAI_DEPLOYMENT = gpt-4o-mini
-   - AZURE_OPENAI_API_VERSION = 2024-10-21
+   - OPENAI_API_KEY = <key>
+   - OPENAI_MODEL = gpt-4o-mini
 3. Visit `/` → redirects to `/INDEX.html` (your Demo_0005).
 
 ## Excel-driven refresh

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -5,6 +5,8 @@
 2. Add Env Vars in Vercel → Settings → Environment Variables:
    - OPENAI_API_KEY = <key>
    - OPENAI_MODEL = gpt-4o-mini
+   - OPENAI_ORGANIZATION = <org-id> (optional, for account-scoped keys)
+   - OPENAI_PROJECT_ID = <project-id> (optional, for project-scoped keys)
 3. Visit `/` → redirects to `/INDEX.html` (your Demo_0005).
 
 ## Excel-driven refresh

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -16,3 +16,12 @@ pip install pandas numpy openpyxl
 python tools\refresh_index.py Soha-Usage-Price-updated.xlsx public\INDEX.html
 ```
 This recomputes KPIs, Top Users (with Conferences), Recommendations, At‑Risk and exports CSVs to `public/data/`.
+
+## Verify agent endpoints locally
+Use the mocked OpenAI harness to exercise both agent handlers without calling the real API:
+
+```bash
+node --loader ./tools/ts-loader.mjs tools/test-agent.mjs
+```
+
+The script streams fake OpenAI responses through the route logic and asserts that both synchronous and streaming endpoints emit the expected payloads and completion events.

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -7,7 +7,7 @@ type ChatRequestBody = {
   message?: unknown;
 };
 
-type AzureChatCompletion = {
+type OpenAIChatCompletion = {
   choices?: Array<{
     message?: {
       content?: string;
@@ -35,26 +35,21 @@ export async function POST(req: NextRequest) {
     : 'Hello';
 
   try {
-    const endpoint = process.env.AZURE_OPENAI_ENDPOINT;
-    const deployment = process.env.AZURE_OPENAI_DEPLOYMENT;
-    const apiVersion = process.env.AZURE_OPENAI_API_VERSION;
-    const apiKey = process.env.AZURE_OPENAI_API_KEY;
+    const apiKey = process.env.OPENAI_API_KEY;
+    const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
 
-    validateEnv('AZURE_OPENAI_ENDPOINT', endpoint);
-    validateEnv('AZURE_OPENAI_DEPLOYMENT', deployment);
-    validateEnv('AZURE_OPENAI_API_VERSION', apiVersion);
-    validateEnv('AZURE_OPENAI_API_KEY', apiKey);
+    validateEnv('OPENAI_API_KEY', apiKey);
 
-    const url = new URL(`/openai/deployments/${deployment}/chat/completions`, endpoint);
-    url.searchParams.set('api-version', apiVersion);
+    const url = 'https://api.openai.com/v1/chat/completions';
 
-    const response = await fetch(url.toString(), {
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'api-key': apiKey,
+        Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
+        model,
         messages: [
           {
             role: 'system',
@@ -71,11 +66,32 @@ export async function POST(req: NextRequest) {
     });
 
     if (!response.ok) {
-      const detail = await response.text();
-      return NextResponse.json({ error: 'LLM error', detail }, { status: 500 });
+      const fallbackStatus = response.status >= 400 && response.status <= 599 ? response.status : 500;
+      const contentType = response.headers.get('content-type') ?? '';
+      let detail: unknown;
+
+      if (contentType.includes('application/json')) {
+        try {
+          detail = await response.json();
+        } catch {
+          detail = await response.text();
+        }
+      } else {
+        detail = await response.text();
+      }
+
+      return NextResponse.json(
+        {
+          error: 'LLM error',
+          detail,
+          status: response.status,
+          statusText: response.statusText,
+        },
+        { status: fallbackStatus },
+      );
     }
 
-    const data = (await response.json()) as AzureChatCompletion;
+    const data = (await response.json()) as OpenAIChatCompletion;
     const text = data?.choices?.[0]?.message?.content ?? '';
 
     return NextResponse.json({ text });

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_TEMPERATURE,
   OPENAI_CHAT_URL,
   buildMessages,
+  createOpenAIHeaders,
   getUserMessage,
   readErrorDetail,
   type ChatRequestBody,
@@ -37,15 +38,14 @@ export async function POST(req: NextRequest) {
   try {
     const apiKey = process.env.OPENAI_API_KEY;
     const model = process.env.OPENAI_MODEL ?? DEFAULT_MODEL;
+    const organization = process.env.OPENAI_ORGANIZATION?.trim();
+    const project = (process.env.OPENAI_PROJECT_ID ?? process.env.OPENAI_PROJECT)?.trim();
 
     validateEnv('OPENAI_API_KEY', apiKey);
 
     const response = await fetch(OPENAI_CHAT_URL, {
       method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
+      headers: createOpenAIHeaders(apiKey, { organization, project }),
       body: JSON.stringify({
         model,
         messages: buildMessages(userMessage),

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -10,6 +10,7 @@ import {
   OPENAI_CHAT_URL,
   buildMessages,
   getUserMessage,
+  readErrorDetail,
   type ChatRequestBody,
   validateEnv,
 } from './shared';
@@ -55,18 +56,7 @@ export async function POST(req: NextRequest) {
 
     if (!response.ok) {
       const fallbackStatus = response.status >= 400 && response.status <= 599 ? response.status : 500;
-      const contentType = response.headers.get('content-type') ?? '';
-      let detail: unknown;
-
-      if (contentType.includes('application/json')) {
-        try {
-          detail = await response.json();
-        } catch {
-          detail = await response.text();
-        }
-      } else {
-        detail = await response.text();
-      }
+      const detail = await readErrorDetail(response);
 
       return NextResponse.json(
         {

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -3,9 +3,16 @@ export const preferredRegion = ['sin1', 'hkg1', 'bom1'];
 
 import { NextRequest, NextResponse } from 'next/server';
 
-type ChatRequestBody = {
-  message?: unknown;
-};
+import {
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_MODEL,
+  DEFAULT_TEMPERATURE,
+  OPENAI_CHAT_URL,
+  buildMessages,
+  getUserMessage,
+  type ChatRequestBody,
+  validateEnv,
+} from './shared';
 
 type OpenAIChatCompletion = {
   choices?: Array<{
@@ -14,12 +21,6 @@ type OpenAIChatCompletion = {
     };
   }>;
 };
-
-function validateEnv(variable: string, value: string | undefined): asserts value is string {
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${variable}`);
-  }
-}
 
 export async function POST(req: NextRequest) {
   let body: ChatRequestBody;
@@ -30,19 +31,15 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const userMessage = typeof body?.message === 'string' && body.message.trim().length > 0
-    ? body.message
-    : 'Hello';
+  const userMessage = getUserMessage(body, 'Hello');
 
   try {
     const apiKey = process.env.OPENAI_API_KEY;
-    const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
+    const model = process.env.OPENAI_MODEL ?? DEFAULT_MODEL;
 
     validateEnv('OPENAI_API_KEY', apiKey);
 
-    const url = 'https://api.openai.com/v1/chat/completions';
-
-    const response = await fetch(url, {
+    const response = await fetch(OPENAI_CHAT_URL, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
@@ -50,18 +47,9 @@ export async function POST(req: NextRequest) {
       },
       body: JSON.stringify({
         model,
-        messages: [
-          {
-            role: 'system',
-            content: 'You are a helpful assistant for a Singapore Government analysis portal.',
-          },
-          {
-            role: 'user',
-            content: userMessage,
-          },
-        ],
-        temperature: 0.2,
-        max_tokens: 500,
+        messages: buildMessages(userMessage),
+        temperature: DEFAULT_TEMPERATURE,
+        max_tokens: DEFAULT_MAX_TOKENS,
       }),
     });
 

--- a/app/api/agent/shared.ts
+++ b/app/api/agent/shared.ts
@@ -25,3 +25,17 @@ export function buildMessages(userMessage: string) {
     { role: 'user' as const, content: userMessage },
   ];
 }
+
+export async function readErrorDetail(response: Response): Promise<unknown> {
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      return await response.json();
+    } catch {
+      return await response.text();
+    }
+  }
+
+  return await response.text();
+}

--- a/app/api/agent/shared.ts
+++ b/app/api/agent/shared.ts
@@ -8,10 +8,32 @@ export const DEFAULT_TEMPERATURE = 0.2;
 export const DEFAULT_MAX_TOKENS = 600;
 export const SYSTEM_PROMPT = 'You are a helpful assistant for a Singapore Government analysis portal.';
 
+export type OpenAIHeaderOptions = {
+  organization?: string | undefined;
+  project?: string | undefined;
+};
+
 export function validateEnv(variable: string, value: string | undefined): asserts value is string {
   if (!value) {
     throw new Error(`Missing required environment variable: ${variable}`);
   }
+}
+
+export function createOpenAIHeaders(apiKey: string, options: OpenAIHeaderOptions = {}) {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  if (options.organization) {
+    headers['OpenAI-Organization'] = options.organization;
+  }
+
+  if (options.project) {
+    headers['OpenAI-Project'] = options.project;
+  }
+
+  return headers;
 }
 
 export function getUserMessage(body: ChatRequestBody | undefined, fallback: string): string {

--- a/app/api/agent/shared.ts
+++ b/app/api/agent/shared.ts
@@ -1,0 +1,27 @@
+export type ChatRequestBody = {
+  message?: unknown;
+};
+
+export const OPENAI_CHAT_URL = 'https://api.openai.com/v1/chat/completions';
+export const DEFAULT_MODEL = 'gpt-4o-mini';
+export const DEFAULT_TEMPERATURE = 0.2;
+export const DEFAULT_MAX_TOKENS = 600;
+export const SYSTEM_PROMPT = 'You are a helpful assistant for a Singapore Government analysis portal.';
+
+export function validateEnv(variable: string, value: string | undefined): asserts value is string {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${variable}`);
+  }
+}
+
+export function getUserMessage(body: ChatRequestBody | undefined, fallback: string): string {
+  const message = typeof body?.message === 'string' ? body.message.trim() : '';
+  return message.length > 0 ? message : fallback;
+}
+
+export function buildMessages(userMessage: string) {
+  return [
+    { role: 'system' as const, content: SYSTEM_PROMPT },
+    { role: 'user' as const, content: userMessage },
+  ];
+}

--- a/app/api/agent/stream/route.ts
+++ b/app/api/agent/stream/route.ts
@@ -10,11 +10,10 @@ import {
   OPENAI_CHAT_URL,
   buildMessages,
   getUserMessage,
+  readErrorDetail,
   type ChatRequestBody,
   validateEnv,
 } from '../shared';
-
-type OpenAIErrorDetail = unknown;
 
 const SSE_HEADERS = {
   'Content-Type': 'text/event-stream; charset=utf-8',
@@ -24,20 +23,6 @@ const SSE_HEADERS = {
 
 function formatSSE(event: string, data: unknown) {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-}
-
-async function readErrorDetail(response: Response): Promise<OpenAIErrorDetail> {
-  const contentType = response.headers.get('content-type') ?? '';
-
-  if (contentType.includes('application/json')) {
-    try {
-      return await response.json();
-    } catch {
-      return await response.text();
-    }
-  }
-
-  return await response.text();
 }
 
 export async function POST(req: NextRequest) {
@@ -106,6 +91,18 @@ export async function POST(req: NextRequest) {
 
     const stream = new ReadableStream({
       async start(controller) {
+        let released = false;
+        const releaseReader = () => {
+          if (!released) {
+            try {
+              reader.releaseLock();
+            } catch {
+              // Ignore release errors; the reader may already be released.
+            }
+            released = true;
+          }
+        };
+
         try {
           let buffer = '';
 
@@ -128,6 +125,7 @@ export async function POST(req: NextRequest) {
               const data = line.slice(5).trim();
               if (data === '[DONE]') {
                 controller.enqueue(encoder.encode(formatSSE('done', {})));
+                releaseReader();
                 controller.close();
                 return;
               }
@@ -136,24 +134,29 @@ export async function POST(req: NextRequest) {
                 const obj = JSON.parse(data);
                 const delta = obj?.choices?.[0]?.delta?.content;
                 if (delta) {
-                  controller.enqueue(encoder.encode(`data: ${JSON.stringify({ text: delta })}\n\n`));
+                  controller.enqueue(encoder.encode(formatSSE('message', { text: delta })));
                 }
               } catch (error) {
                 controller.enqueue(encoder.encode(formatSSE('error', {
                   detail: error instanceof Error ? error.message : String(error),
                 })));
+                releaseReader();
                 controller.close();
                 return;
               }
             }
           }
 
+          releaseReader();
           controller.close();
         } catch (error) {
           controller.enqueue(encoder.encode(formatSSE('error', {
             detail: error instanceof Error ? error.message : String(error),
           })));
+          releaseReader();
           controller.close();
+        } finally {
+          releaseReader();
         }
       },
     });

--- a/app/api/agent/stream/route.ts
+++ b/app/api/agent/stream/route.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_TEMPERATURE,
   OPENAI_CHAT_URL,
   buildMessages,
+  createOpenAIHeaders,
   getUserMessage,
   readErrorDetail,
   type ChatRequestBody,
@@ -42,6 +43,8 @@ export async function POST(req: NextRequest) {
   try {
     const apiKey = process.env.OPENAI_API_KEY;
     const model = process.env.OPENAI_MODEL ?? DEFAULT_MODEL;
+    const organization = process.env.OPENAI_ORGANIZATION?.trim();
+    const project = (process.env.OPENAI_PROJECT_ID ?? process.env.OPENAI_PROJECT)?.trim();
 
     validateEnv('OPENAI_API_KEY', apiKey);
 
@@ -50,10 +53,7 @@ export async function POST(req: NextRequest) {
     try {
       upstream = await fetch(OPENAI_CHAT_URL, {
         method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+        headers: createOpenAIHeaders(apiKey, { organization, project }),
         body: JSON.stringify({
           model,
           messages: buildMessages(userMessage),

--- a/app/api/agent/stream/route.ts
+++ b/app/api/agent/stream/route.ts
@@ -1,26 +1,176 @@
-export const runtime='edge';
-export const preferredRegion=['sin1','hkg1','bom1'];
+export const runtime = 'edge';
+export const preferredRegion = ['sin1', 'hkg1', 'bom1'];
+
 import { NextRequest } from 'next/server';
+
+type ChatRequestBody = {
+  message?: unknown;
+};
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream; charset=utf-8',
+  'Cache-Control': 'no-cache, no-transform',
+  Connection: 'keep-alive',
+} as const;
+
+function validateEnv(variable: string, value: string | undefined): asserts value is string {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${variable}`);
+  }
+}
+
+function formatSSE(event: string, data: unknown) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
 export async function POST(req: NextRequest) {
-  const { message } = await req.json();
-  const encoder = new TextEncoder();
-  const stream = new ReadableStream({
-    async start(controller){
-      try{
-        const url = `${process.env.AZURE_OPENAI_ENDPOINT}/openai/deployments/${process.env.AZURE_OPENAI_DEPLOYMENT}/chat/completions?api-version=${process.env.AZURE_OPENAI_API_VERSION}`;
-        const resp = await fetch(url, { method:'POST', headers:{ 'content-type':'application/json', 'api-key': process.env.AZURE_OPENAI_API_KEY! }, body: JSON.stringify({ messages:[{role:'system',content:'You are a helpful assistant for a Singapore Government analysis portal.'},{role:'user',content: message||'Hello'}], temperature:0.2, max_tokens:600, stream:true }) });
-        if(!resp.ok || !resp.body){ const detail = await resp.text(); controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ detail })}\n\n`)); controller.close(); return; }
-        const reader = resp.body.getReader(); const decoder = new TextDecoder(); let buffer='';
-        while(true){ const { value, done } = await reader.read(); if(done) break; buffer += decoder.decode(value, { stream:true });
-          const lines = buffer.split('\n'); buffer = lines.pop() || '';
-          for(const raw of lines){ const line = raw.trim(); if(!line.startsWith('data:')) continue; const data = line.slice(5).trim();
-            if(data==='[DONE]'){ controller.enqueue(encoder.encode('event: done\ndata: {}\n\n')); controller.close(); return; }
-            try{ const obj = JSON.parse(data); const delta = obj?.choices?.[0]?.delta?.content; if(delta){ controller.enqueue(encoder.encode(`data: ${JSON.stringify({ text: delta })}\n\n`)); } }catch{}
-          }
-        }
-        controller.close();
-      }catch(e){ controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({ detail:String(e) })}\n\n`)); controller.close(); }
+  let body: ChatRequestBody;
+
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(formatSSE('error', { detail: 'Invalid JSON body' }), {
+      headers: SSE_HEADERS,
+      status: 400,
+    });
+  }
+
+  const userMessage = typeof body?.message === 'string' && body.message.trim().length > 0
+    ? body.message
+    : 'Hello';
+
+  try {
+    const apiKey = process.env.OPENAI_API_KEY;
+    const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
+
+    validateEnv('OPENAI_API_KEY', apiKey);
+
+    const url = 'https://api.openai.com/v1/chat/completions';
+
+    let upstream: Response;
+
+    try {
+      upstream = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful assistant for a Singapore Government analysis portal.',
+            },
+            {
+              role: 'user',
+              content: userMessage,
+            },
+          ],
+          temperature: 0.2,
+          max_tokens: 600,
+          stream: true,
+        }),
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      return new Response(formatSSE('error', { detail }), {
+        headers: SSE_HEADERS,
+        status: 504,
+      });
     }
-  });
-  return new Response(stream, { headers:{ 'Content-Type':'text/event-stream; charset=utf-8', 'Cache-Control':'no-cache, no-transform', 'Connection':'keep-alive' } });
+
+    const fallbackStatus = upstream.status >= 400 && upstream.status <= 599 ? upstream.status : 500;
+
+    if (!upstream.ok || !upstream.body) {
+      const contentType = upstream.headers.get('content-type') ?? '';
+      let detail: unknown;
+
+      if (contentType.includes('application/json')) {
+        try {
+          detail = await upstream.json();
+        } catch {
+          detail = await upstream.text();
+        }
+      } else {
+        detail = await upstream.text();
+      }
+
+      return new Response(formatSSE('error', {
+        detail,
+        status: upstream.status,
+        statusText: upstream.statusText,
+      }), {
+        headers: SSE_HEADERS,
+        status: fallbackStatus,
+      });
+    }
+
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const reader = upstream.body.getReader();
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          let buffer = '';
+
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) {
+              break;
+            }
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() ?? '';
+
+            for (const raw of lines) {
+              const line = raw.trim();
+              if (!line.startsWith('data:')) {
+                continue;
+              }
+
+              const data = line.slice(5).trim();
+              if (data === '[DONE]') {
+                controller.enqueue(encoder.encode(formatSSE('done', {})));
+                controller.close();
+                return;
+              }
+
+              try {
+                const obj = JSON.parse(data);
+                const delta = obj?.choices?.[0]?.delta?.content;
+                if (delta) {
+                  controller.enqueue(encoder.encode(`data: ${JSON.stringify({ text: delta })}\n\n`));
+                }
+              } catch (error) {
+                controller.enqueue(encoder.encode(formatSSE('error', {
+                  detail: error instanceof Error ? error.message : String(error),
+                })));
+                controller.close();
+                return;
+              }
+            }
+          }
+
+          controller.close();
+        } catch (error) {
+          controller.enqueue(encoder.encode(formatSSE('error', {
+            detail: error instanceof Error ? error.message : String(error),
+          })));
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(stream, { headers: SSE_HEADERS });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return new Response(formatSSE('error', { detail }), {
+      headers: SSE_HEADERS,
+      status: detail.startsWith('Missing required environment variable') ? 500 : 504,
+    });
+  }
 }

--- a/app/api/agent/stream/route.ts
+++ b/app/api/agent/stream/route.ts
@@ -3,9 +3,18 @@ export const preferredRegion = ['sin1', 'hkg1', 'bom1'];
 
 import { NextRequest } from 'next/server';
 
-type ChatRequestBody = {
-  message?: unknown;
-};
+import {
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_MODEL,
+  DEFAULT_TEMPERATURE,
+  OPENAI_CHAT_URL,
+  buildMessages,
+  getUserMessage,
+  type ChatRequestBody,
+  validateEnv,
+} from '../shared';
+
+type OpenAIErrorDetail = unknown;
 
 const SSE_HEADERS = {
   'Content-Type': 'text/event-stream; charset=utf-8',
@@ -13,14 +22,22 @@ const SSE_HEADERS = {
   Connection: 'keep-alive',
 } as const;
 
-function validateEnv(variable: string, value: string | undefined): asserts value is string {
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${variable}`);
-  }
-}
-
 function formatSSE(event: string, data: unknown) {
   return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+async function readErrorDetail(response: Response): Promise<OpenAIErrorDetail> {
+  const contentType = response.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    try {
+      return await response.json();
+    } catch {
+      return await response.text();
+    }
+  }
+
+  return await response.text();
 }
 
 export async function POST(req: NextRequest) {
@@ -35,22 +52,18 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const userMessage = typeof body?.message === 'string' && body.message.trim().length > 0
-    ? body.message
-    : 'Hello';
+  const userMessage = getUserMessage(body, 'Hello');
 
   try {
     const apiKey = process.env.OPENAI_API_KEY;
-    const model = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
+    const model = process.env.OPENAI_MODEL ?? DEFAULT_MODEL;
 
     validateEnv('OPENAI_API_KEY', apiKey);
-
-    const url = 'https://api.openai.com/v1/chat/completions';
 
     let upstream: Response;
 
     try {
-      upstream = await fetch(url, {
+      upstream = await fetch(OPENAI_CHAT_URL, {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
@@ -58,18 +71,9 @@ export async function POST(req: NextRequest) {
         },
         body: JSON.stringify({
           model,
-          messages: [
-            {
-              role: 'system',
-              content: 'You are a helpful assistant for a Singapore Government analysis portal.',
-            },
-            {
-              role: 'user',
-              content: userMessage,
-            },
-          ],
-          temperature: 0.2,
-          max_tokens: 600,
+          messages: buildMessages(userMessage),
+          temperature: DEFAULT_TEMPERATURE,
+          max_tokens: DEFAULT_MAX_TOKENS,
           stream: true,
         }),
       });
@@ -84,18 +88,7 @@ export async function POST(req: NextRequest) {
     const fallbackStatus = upstream.status >= 400 && upstream.status <= 599 ? upstream.status : 500;
 
     if (!upstream.ok || !upstream.body) {
-      const contentType = upstream.headers.get('content-type') ?? '';
-      let detail: unknown;
-
-      if (contentType.includes('application/json')) {
-        try {
-          detail = await upstream.json();
-        } catch {
-          detail = await upstream.text();
-        }
-      } else {
-        detail = await upstream.text();
-      }
+      const detail = await readErrorDetail(upstream);
 
       return new Response(formatSSE('error', {
         detail,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-export const metadata: Metadata = { title: 'Demo 0005 – Vercel', description: 'Static demo with Azure OpenAI agent' };
+export const metadata: Metadata = { title: 'Demo 0005 – Vercel', description: 'Static demo with OpenAI Platform agent' };
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (<html lang="en"><body style={{margin:0}}>{children}</body></html>);
 }

--- a/public/INDEX.html
+++ b/public/INDEX.html
@@ -1203,7 +1203,7 @@
     <div class="chat-row">
       <textarea id="ai-chat-input" class="chat-input" placeholder="Ask the agent about usage, costs, or insights..."></textarea>
       <button id="ai-chat-send" class="chat-send">Send</button>
-      <small class="chat-hint">Azure OpenAI</small>
+      <small class="chat-hint">OpenAI Platform</small>
     </div>
     <div id="ai-chat-output" class="chat-output"></div>
   </div>

--- a/tools/test-agent.mjs
+++ b/tools/test-agent.mjs
@@ -40,9 +40,16 @@ function createJsonResponse(json, init) {
 
 async function run() {
   process.env.OPENAI_API_KEY = 'test-key';
+  process.env.OPENAI_ORGANIZATION = 'org-test';
+  process.env.OPENAI_PROJECT_ID = 'proj-test';
 
   globalThis.fetch = async (_input, init) => {
     const body = init?.body ? JSON.parse(init.body) : {};
+    const headers = new Headers(init?.headers);
+    assert.equal(headers.get('authorization'), 'Bearer test-key');
+    assert.equal(headers.get('content-type'), 'application/json');
+    assert.equal(headers.get('openai-organization'), 'org-test');
+    assert.equal(headers.get('openai-project'), 'proj-test');
     if (body.stream) {
       return createStreamingResponse([
         'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
@@ -107,33 +114,58 @@ async function testStreamEndpoint() {
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
 
-    const lines = buffer.split('\n\n');
-    buffer = lines.pop() ?? '';
+    const frames = buffer.split('\n\n');
+    buffer = frames.pop() ?? '';
 
-    for (const chunk of lines) {
-      if (chunk.startsWith('event: done')) {
+    for (const frame of frames) {
+      const { event, data } = parseSSEFrame(frame);
+      if (event === 'done') {
         doneEvent = true;
         continue;
       }
-      if (!chunk.startsWith('data:')) {
+      if (event !== 'message' || !data) {
         continue;
       }
-      const json = JSON.parse(chunk.slice(5).trim());
+      const json = JSON.parse(data);
       if (json.text) {
         received += json.text;
       }
     }
   }
 
-  if (buffer.startsWith('data:')) {
-    const json = JSON.parse(buffer.slice(5).trim());
-    if (json.text) {
-      received += json.text;
+  const trailing = buffer.trim();
+  if (trailing) {
+    const { event, data } = parseSSEFrame(trailing);
+    if (event === 'message' && data) {
+      const json = JSON.parse(data);
+      if (json.text) {
+        received += json.text;
+      }
+    }
+    if (event === 'done') {
+      doneEvent = true;
     }
   }
 
   assert.equal(received, 'Hello world');
   assert(doneEvent, 'expected done event to be emitted');
+}
+
+function parseSSEFrame(frame) {
+  let event = 'message';
+  const dataLines = [];
+
+  for (const rawLine of frame.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith('event:')) {
+      event = line.slice(6).trim();
+    } else if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trim());
+    }
+  }
+
+  return { event, data: dataLines.length > 0 ? dataLines.join('\n') : undefined };
 }
 
 await run();

--- a/tools/test-agent.mjs
+++ b/tools/test-agent.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server.js';
+
+import { POST as chatPOST } from '../app/api/agent/route';
+import { POST as streamPOST } from '../app/api/agent/stream/route';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const encoder = new TextEncoder();
+
+if (typeof globalThis.self === 'undefined') {
+  globalThis.self = globalThis;
+}
+
+function createStreamingResponse(chunks, init) {
+  const stream = new ReadableStream({
+    start(controller) {
+      let index = 0;
+      const push = () => {
+        if (index >= chunks.length) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(chunks[index++]));
+        queueMicrotask(push);
+      };
+      push();
+    },
+  });
+
+  return new Response(stream, init);
+}
+
+function createJsonResponse(json, init) {
+  return new Response(JSON.stringify(json), {
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+  });
+}
+
+async function run() {
+  process.env.OPENAI_API_KEY = 'test-key';
+
+  globalThis.fetch = async (_input, init) => {
+    const body = init?.body ? JSON.parse(init.body) : {};
+    if (body.stream) {
+      return createStreamingResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ], {
+        headers: { 'content-type': 'text/event-stream' },
+        status: 200,
+        statusText: 'OK',
+      });
+    }
+
+    return createJsonResponse({
+      choices: [
+        {
+          message: {
+            content: 'Hello world',
+          },
+        },
+      ],
+    });
+  };
+
+  try {
+    await testChatEndpoint();
+    await testStreamEndpoint();
+    console.log('All agent endpoint tests passed');
+  } finally {
+    globalThis.fetch = ORIGINAL_FETCH;
+  }
+}
+
+async function testChatEndpoint() {
+  const request = new NextRequest('http://localhost/api/agent', {
+    method: 'POST',
+    body: JSON.stringify({ message: 'Hello' }),
+  });
+
+  const response = await chatPOST(request);
+  assert.equal(response.status, 200);
+  const data = await response.json();
+  assert.equal(data.text, 'Hello world');
+}
+
+async function testStreamEndpoint() {
+  const request = new NextRequest('http://localhost/api/agent/stream', {
+    method: 'POST',
+    body: JSON.stringify({ message: 'Hello' }),
+  });
+
+  const response = await streamPOST(request);
+  assert.equal(response.status, 200);
+  const reader = response.body?.getReader();
+  assert(reader, 'expected response to include a readable body');
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let received = '';
+  let doneEvent = false;
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split('\n\n');
+    buffer = lines.pop() ?? '';
+
+    for (const chunk of lines) {
+      if (chunk.startsWith('event: done')) {
+        doneEvent = true;
+        continue;
+      }
+      if (!chunk.startsWith('data:')) {
+        continue;
+      }
+      const json = JSON.parse(chunk.slice(5).trim());
+      if (json.text) {
+        received += json.text;
+      }
+    }
+  }
+
+  if (buffer.startsWith('data:')) {
+    const json = JSON.parse(buffer.slice(5).trim());
+    if (json.text) {
+      received += json.text;
+    }
+  }
+
+  assert.equal(received, 'Hello world');
+  assert(doneEvent, 'expected done event to be emitted');
+}
+
+await run();

--- a/tools/ts-loader.mjs
+++ b/tools/ts-loader.mjs
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+import ts from 'typescript';
+
+const compilerOptions = {
+  module: ts.ModuleKind.ESNext,
+  target: ts.ScriptTarget.ES2022,
+  jsx: ts.JsxEmit.Preserve,
+  esModuleInterop: true,
+};
+
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier === 'next/server') {
+    const result = await defaultResolve('next/server.js', context, defaultResolve);
+    return { url: result.url, shortCircuit: true };
+  }
+
+  try {
+    return await defaultResolve(specifier, context, defaultResolve);
+  } catch (error) {
+    if (specifier.startsWith('.') || specifier.startsWith('/')) {
+      const withTs = specifier.endsWith('.ts') ? specifier : `${specifier}.ts`;
+      const url = new URL(withTs, context.parentURL);
+      return { url: url.href, shortCircuit: true };
+    }
+    throw error;
+  }
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.ts')) {
+    const source = await readFile(new URL(url));
+    const { outputText } = ts.transpileModule(source.toString(), { compilerOptions });
+    return { format: 'module', source: outputText, shortCircuit: true };
+  }
+
+  return defaultLoad(url, context, defaultLoad);
+}


### PR DESCRIPTION
## Summary
- surface upstream OpenAI status codes and error bodies when chat completions fail
- harden the streaming agent route with structured SSE helpers, env validation, and detailed error propagation

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db02e0acf483269e9bc91bda7d365a